### PR TITLE
Removing extraneous (and outdated) node-sbus dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "documentdb-q-promises": "^0.9.3",
     "easy-config": "^0.4.4",
     "q": "^1.2.0",
-    "sbus-amqp10": "^0.1.0"
+    "sbus-amqp10": "^0.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "documentdb": "^0.9.3",
     "documentdb-q-promises": "^0.9.3",
     "easy-config": "^0.4.4",
-    "node-sbus": "*",
     "q": "^1.2.0",
     "sbus-amqp10": "^0.1.0"
   }


### PR DESCRIPTION
'sbus-amqp10' pulls in both 'sbus' and 'amqp10' and basically connects the two of them together, so a separate 'sbus' dependency is not necessary.  Also, the NPM names have changed from 'node-sbus'/'node-sbus-amqp10'/'node-amqp-1-0' to ones without the extraneous 'node-' prefix (given that they're already in NPM so 'node-' is kind of implied.
